### PR TITLE
fix issue loading when patches where applied in the wrong order

### DIFF
--- a/resources/assets/volumetricshadingupdated/shaderpatches/overexposure.yaml
+++ b/resources/assets/volumetricshadingupdated/shaderpatches/overexposure.yaml
@@ -116,7 +116,7 @@
 
 - type: token
   filename: standard.fsh
-  tokens: outGlow = vec4
+  tokens: outGlow =
   content: |
     glow += extraOutGlow;
-    outGlow = vec4
+    outGlow =


### PR DESCRIPTION
This should fix the issue using the version on the moddb

For good meassure you can send me a copy of your build before you do a release to test and verify

The underlying issues seems to be that the windows net7 build mod on linux seems to patch the shaders in a different order then on linux. Not sure why when build on linux it is fine.

I tried to sort the patches but that seems to have no effect i assume that is handled by the engine (maybe need more investigation) but this should work for now

----

The patch that should be applied was not finding the the source to apply it since outGlow = vec4
https://github.com/michalkr52/VolumetricShadingUpdated/blob/net7/resources/assets/volumetricshadingupdated/shaderpatches/overexposure.yaml#L117


was not in the code anymore it was split into multiple lines by probably this one

https://github.com/michalkr52/VolumetricShadingUpdated/blob/net7/resources/assets/volumetricshadingupdated/shaderpatches/deferredlighting.yaml#L90
i have tried same settings on windows and linux so it should apply the same patches 

whit this new fix we do not need to rely that what oder those two patches are applied